### PR TITLE
Fix scroll issue when changing pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,6 +26,7 @@ import { BatchClawback } from "./pages/BatchClawback";
 import { BatchFreeze } from "./pages/BatchFreeze";
 import { VaultSendTool } from "./pages/VaultSendTool";
 import { SimpleBatchMint } from "./pages/SimpleBatchMint";
+import ScrollToTop from "./components/ScrollToTop";
 
 function App() {
   return (
@@ -43,6 +44,7 @@ function App() {
         theme="dark"
       />
       <Router>
+        <ScrollToTop />
         <Header />
         <Routes>
           <Route path="/" element={<Home />} />

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
Fixes the bug where the page for a tool that is far down the list on the home page appears blank because it is scrolled beyond its page size.