### PR TITLE
Simple airdrop multimint

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -754,12 +754,16 @@ export async function createFreezeTransactions(
   }
 }
 
-async function getAssetCreatorWallet(assetId, selectNetwork) {
+export async function getAssetCreatorWallet(assetId) {
   try {
-    const url = getNodeURL(selectNetwork) + `/v2/assets/${assetId}`;
+    const nodeUrl = getNodeURL();
+    const url = `${nodeUrl}/v2/assets/${assetId}`;
     const response = await axios.get(url);
+    console.log('getAssetCreatorWallet '+JSON.stringify(response));
+    console.log('getAssetCreatorWallet '+response.data.params.creator);
     return response.data.params.creator;
   } catch (err) {
+    console.log('error '+err);
     return "";
   }
 }
@@ -777,7 +781,7 @@ export async function createAssetOptoutTransactions(
   let txnsArray = [];
   const wallet = localStorage.getItem("wallet");
   for (let i = 0; i < assets.length; i++) {
-    const creatorAddress = await getAssetCreatorWallet(assets[i], networkType);
+    const creatorAddress = await getAssetCreatorWallet(assets[i]);
     if (creatorAddress !== "") {
       const tx = makeAssetTransferTxnWithSuggestedParamsFromObject({
         from: wallet,
@@ -1071,7 +1075,18 @@ export async function getOwnerAddressOfAsset(assetId) {
     return "";
   }
 }
-
+export async function getOwnerAddressAmountOfAsset(assetId) {
+  try {
+    const url =
+      getIndexerURL() +
+      `/v2/assets/${assetId}/balances?currency-greater-than=0`;
+    const response = await axios.get(url);
+    return response;
+  } catch (err) {
+    console.log(err);
+    return "";
+  }
+}
 export async function getRandListingAsset(assetId) {
   try {
     const url = `https://www.randswap.com/v1/listings/asset/${assetId}`;


### PR DESCRIPTION
Updated SimpleAirdropTool.jsx 
- toggle between using Creator Wallet vs Multi-mint asset ID for distribution
- handle holder address and amount held to calculate the amount to send in the airdrop tool
- ignores creator wallet in airdrop when using multi-mint
updated utils.js 
- added new function getOwnerAddressAmountOfAsset
- updated getAssetCreatorWallet with export and modified so it doesn't require passing in networkType parameter
- updated createAssetOptoutTransactions as it used getAssetCreatorWallet function

Screenshots demonstrating new layout, and generated transactions for the list of holders. Example used was the first address in the console
https://allo.info/asset/1024883023/holders?address=BAHGZBWM73BMMR2QR2QUANSABLOQLIIQNSPWF26UF5EW7DJUNQM6QFQNIE

<img width="1426" alt="Screenshot 2024-09-01 at 3 01 09 PM" src="https://github.com/user-attachments/assets/2fe8c2a6-d24d-4d49-b81a-6dc8c6ec25f3">
<img width="1426" alt="Screenshot 2024-09-01 at 3 01 37 PM" src="https://github.com/user-attachments/assets/74e0b840-4afb-4f41-b5df-aa6c777c7a67">
![Screenshot_20240901_150036_Pera Algo Wallet](https://github.com/user-attachments/assets/2e372f51-26f0-4813-98c6-d89a7ebad3ed)


