### PR TITLE
fix getNfDomainsInBulk, remove wallet toLowerCase

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1021,7 +1021,7 @@ export async function getNfDomainsInBulk(wallets, bulkSize = 20) {
   for (let i = 0; i < uniqueWallets.length; i += bulkSize) {
     const chunk = uniqueWallets
       .slice(i, i + bulkSize)
-      .map((wallet) => `address=${wallet.toLowerCase()}`)
+      .map((wallet) => `address=${wallet}`)
       .join("&");
     try {
       const nfdLookup = await fetchNFDJSON(


### PR DESCRIPTION
bug fix: removed .toLowerCase function on wallet address for the function getNfDomainsInBulk