### PR TITLE
bug fix in arc3 - simple mint classis

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -455,9 +455,6 @@ export async function createARC3AssetMintArray(
       const atc = new algosdk.AtomicTransactionComposer();
       atc.addTransaction({ txn: asset_create_tx, signer: txSigner });
       atc.addTransaction({ txn: fee_tx, signer: txSigner });
-      atc.addMethodCall(
-        await makeCrustPinTx(cid, txSigner, address, algodClient)
-      );
       txnsArray.push(getTxnGroupFromATC(atc));
       toast.info(`Asset ${i + 1} of ${data_for_txns.length} uploaded to IPFS`, {
         autoClose: 200,


### PR DESCRIPTION
Removed Crust pinning transactions while minting using Simple Mint Classic (ARC3) since we are using Pinata for pinning.

Currently, with Crust pinning, the transaction group contains 4 transactions, but we are submitting only 2 at a time, leading to an 'incomplete group transaction' error.

By removing the Crust pinning transactions, the group size is reduced to 2, which aligns with the expected transaction structure when submitting to the network.